### PR TITLE
Slack notification resource deploy

### DIFF
--- a/deploy-concourse/pipeline.yml
+++ b/deploy-concourse/pipeline.yml
@@ -68,9 +68,11 @@ jobs:
         BOSH_TARGET: {{concourse-deployment-bosh-target}}
         BOSH_USERNAME: {{concourse-deployment-bosh-username}}
         BOSH_PASSWORD: {{concourse-deployment-bosh-password}}
+        RELEASE_NAME: slack-notification-resource
+        RELEASE_URL_FILE: slack-notification-release/url
+        RELEASE_VERSION_FILE: slack-notification-release/version
       run:
         path: pipelines/tasks/upload-release.sh
-        args: ["slack-notification-release/url"]
 
 resources:
 - name: pipelines

--- a/deploy-concourse/pipeline.yml
+++ b/deploy-concourse/pipeline.yml
@@ -1,11 +1,37 @@
 ---
 jobs:
+- name: upload-slack-notifications-release
+  plan:
+  - aggregate:
+    - get: pipelines
+      trigger: false
+    - get: slack-notification-release
+      trigger: true
+      params:
+        tarball: false
+  - task: upload-release
+    config:
+      platform: linux
+      image: docker:///18fgsa/concourse-task
+      inputs:
+      - name: pipelines
+      - name: slack-notification-release
+      params:
+        BOSH_TARGET: {{concourse-deployment-bosh-target}}
+        BOSH_USERNAME: {{concourse-deployment-bosh-username}}
+        BOSH_PASSWORD: {{concourse-deployment-bosh-password}}
+        RELEASE_NAME: slack-notification-resource
+        RELEASE_URL_FILE: slack-notification-release/url
+        RELEASE_VERSION_FILE: slack-notification-release/version
+      run:
+        path: pipelines/tasks/upload-release.sh
 - name: deploy-concourse
   serial: true
   plan:
   - aggregate:
     - get: pipelines
       trigger: false
+      passed: [upload-slack-notifications-release]
     - get: concourse-config
       trigger: true
     - get: concourse-private
@@ -47,32 +73,6 @@ jobs:
         - concourse-release/garden-linux-*.tgz
       stemcells:
         - concourse-stemcell/*.tgz
-- name: upload-slack-notifications-release
-  serial: true
-  plan:
-  - aggregate:
-    - get: pipelines
-      trigger: false
-    - get: slack-notification-release
-      trigger: true
-      params:
-        tarball: false
-  - task: upload-release
-    config:
-      platform: linux
-      image: docker:///18fgsa/concourse-task
-      inputs:
-      - name: pipelines
-      - name: slack-notification-release
-      params:
-        BOSH_TARGET: {{concourse-deployment-bosh-target}}
-        BOSH_USERNAME: {{concourse-deployment-bosh-username}}
-        BOSH_PASSWORD: {{concourse-deployment-bosh-password}}
-        RELEASE_NAME: slack-notification-resource
-        RELEASE_URL_FILE: slack-notification-release/url
-        RELEASE_VERSION_FILE: slack-notification-release/version
-      run:
-        path: pipelines/tasks/upload-release.sh
 
 resources:
 - name: pipelines

--- a/deploy-concourse/pipeline.yml
+++ b/deploy-concourse/pipeline.yml
@@ -47,6 +47,30 @@ jobs:
         - concourse-release/garden-linux-*.tgz
       stemcells:
         - concourse-stemcell/*.tgz
+- name: upload-slack-notifications-release
+  serial: true
+  plan:
+  - aggregate:
+    - get: pipelines
+      trigger: false
+    - get: slack-notification-release
+      trigger: true
+      params:
+        tarball: false
+  - task: upload-release
+    config:
+      platform: linux
+      image: docker:///18fgsa/concourse-task
+      inputs:
+      - name: pipelines
+      - name: slack-notification-release
+      params:
+        BOSH_TARGET: {{concourse-deployment-bosh-target}}
+        BOSH_USERNAME: {{concourse-deployment-bosh-username}}
+        BOSH_PASSWORD: {{concourse-deployment-bosh-password}}
+      run:
+        path: pipelines/tasks/upload-release.sh
+        args: ["slack-notification-release/url"]
 
 resources:
 - name: pipelines
@@ -90,3 +114,8 @@ resources:
     password: {{concourse-deployment-bosh-password}}
     deployment: {{concourse-deployment-bosh-deployment}}
     ignore_ssl: true
+
+- name: slack-notification-release
+  type: bosh-io-release
+  source:
+    repository: cloudfoundry-community/slack-notification-resource-boshrelease

--- a/deploy-concourse/pipeline.yml
+++ b/deploy-concourse/pipeline.yml
@@ -1,37 +1,11 @@
 ---
 jobs:
-- name: upload-slack-notifications-release
-  plan:
-  - aggregate:
-    - get: pipelines
-      trigger: false
-    - get: slack-notification-release
-      trigger: true
-      params:
-        tarball: false
-  - task: upload-release
-    config:
-      platform: linux
-      image: docker:///18fgsa/concourse-task
-      inputs:
-      - name: pipelines
-      - name: slack-notification-release
-      params:
-        BOSH_TARGET: {{concourse-deployment-bosh-target}}
-        BOSH_USERNAME: {{concourse-deployment-bosh-username}}
-        BOSH_PASSWORD: {{concourse-deployment-bosh-password}}
-        RELEASE_NAME: slack-notification-resource
-        RELEASE_URL_FILE: slack-notification-release/url
-        RELEASE_VERSION_FILE: slack-notification-release/version
-      run:
-        path: pipelines/tasks/upload-release.sh
 - name: deploy-concourse
   serial: true
   plan:
   - aggregate:
     - get: pipelines
       trigger: false
-      passed: [upload-slack-notifications-release]
     - get: concourse-config
       trigger: true
     - get: concourse-private
@@ -44,6 +18,8 @@ jobs:
         globs:
           - concourse-*.tgz
           - garden-linux-*.tgz
+    - get: slack-notification-release
+      trigger: true
   - task: concourse-decrypt
     file: pipelines/tasks/decrypt.yml
     config:
@@ -71,6 +47,7 @@ jobs:
       releases:
         - concourse-release/concourse-*.tgz
         - concourse-release/garden-linux-*.tgz
+        - slack-notification-release/release.tgz
       stemcells:
         - concourse-stemcell/*.tgz
 

--- a/tasks/upload-release.sh
+++ b/tasks/upload-release.sh
@@ -34,6 +34,7 @@ fi
 #
 # Target BOSH
 #
+echo "Uploading $RELEASE_NAME @ `cat $RELEASE_VERSION_FILE`: `cat $RELEASE_URL_FILE`"
 bosh -n target $BOSH_TARGET
 bosh -n login $BOSH_USERNAME $BOSH_PASSWORD
 bosh -n upload release `cat $RELEASE_URL_FILE` --name $RELEASE_NAME --version `cat $RELEASE_VERSION_FILE`

--- a/tasks/upload-release.sh
+++ b/tasks/upload-release.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# vim: set ft=sh
+
+set -e
+
+#
+# A little environment validation
+#
+if [ -z "$1" ]; then
+  echo "must specify release url" >&2
+  exit 1
+fi
+if [ -z "$BOSH_TARGET" ]; then
+  echo "must specify \$BOSH_TARGET" >&2
+  exit 1
+fi
+if [ -z "$BOSH_USERNAME" ]; then
+  echo "must specify \$BOSH_USERNAME" >&2
+  exit 1
+fi
+if [ -z "$BOSH_PASSWORD" ]; then
+  echo "must specify \$BOSH_PASSWORD" >&2
+  exit 1
+fi
+
+#
+# Target BOSH
+#
+bosh -n target $BOSH_TARGET
+bosh -n login $BOSH_USERNAME $BOSH_PASSWORD
+bosh -n upload release `cat $1` --skip-if-exists

--- a/tasks/upload-release.sh
+++ b/tasks/upload-release.sh
@@ -6,10 +6,6 @@ set -e
 #
 # A little environment validation
 #
-if [ -z "$1" ]; then
-  echo "must specify release url" >&2
-  exit 1
-fi
 if [ -z "$BOSH_TARGET" ]; then
   echo "must specify \$BOSH_TARGET" >&2
   exit 1
@@ -22,10 +18,22 @@ if [ -z "$BOSH_PASSWORD" ]; then
   echo "must specify \$BOSH_PASSWORD" >&2
   exit 1
 fi
+if [ -z "$RELEASE_URL_FILE" ]; then
+  echo "must specify \$RELEASE_URL_FILE" >&2
+  exit 1
+fi
+if [ -z "$RELEASE_NAME" ]; then
+  echo "must specify \$RELEASE_NAME" >&2
+  exit 1
+fi
+if [ -z "$RELEASE_VERSION_FILE" ]; then
+  echo "must specify \$RELEASE_VERSION_FILE" >&2
+  exit 1
+fi
 
 #
 # Target BOSH
 #
 bosh -n target $BOSH_TARGET
 bosh -n login $BOSH_USERNAME $BOSH_PASSWORD
-bosh -n upload release `cat $1` --skip-if-exists
+bosh -n upload release `cat $RELEASE_URL_FILE` --name $RELEASE_NAME --version `cat $RELEASE_VERSION_FILE`


### PR DESCRIPTION
@adrianwebb @dlapiduz
Part 1 of 2 for slack notifications from concourse. 
This adds uploading of the slack notification resource releases via bosh in the concourse pipeline. 

Part 2 will be changes to the concourse manifest to reference the release once it's uploaded so it's available as a valid resource in pipelines.
